### PR TITLE
Updated sketch-tool installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
-###Requirements
+### Requirements
 
 * node
 * Sketch.app
 
-###Installation
+### Installation
 
-1. Install sketch-tool `$ curl -L https://raw.githubusercontent.com/cognitom/dotfiles/master/lib/sketchtool.sh | sudo sh`
+1. Install sketch-tool.
+    * via [Bohemian Coding's site](http://www.sketchapp.com/tool/)
+    * via [brew](http://brew.sh/):
+      1. Make sure you have Homebrew version `0.9.5` or higher. You can check with `$ brew --version`.
+      2. If you don't have [Homebrew Cask](http://caskroom.io/), run `brew tap caskroom/cask`
+      3. Install sketch-tool with `brew cask install sketch-tool`
 2. Run `$ npm install`
 
-###Usage
+### Usage
 
 1. Run `$ gulp`
 2. Work on and save either `app.coffee` or `assets.sketch` in the `src` folder.


### PR DESCRIPTION
We should probably not tell people to download and run executables from other people's dotfiles.

Added instructions for how to install via brew-cask and via clicking.
